### PR TITLE
Feature/3370

### DIFF
--- a/SnapMD.ConnectedCare.ApiModels/HospitalAddress.cs
+++ b/SnapMD.ConnectedCare.ApiModels/HospitalAddress.cs
@@ -1,0 +1,22 @@
+﻿//    Copyright 2015 SnapMD, Inc.
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//        http://www.apache.org/licenses/LICENSE-2.0
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+
+namespace SnapMD.ConnectedCare.ApiModels
+{
+    [Serializable]
+    public class HospitalAddress
+    {
+        public int hospitalId { get; set; }
+        public string address { get; set; }
+    }
+}

--- a/SnapMD.ConnectedCare.ApiModels/SnapMD.ConnectedCare.ApiModels.csproj
+++ b/SnapMD.ConnectedCare.ApiModels/SnapMD.ConnectedCare.ApiModels.csproj
@@ -67,6 +67,7 @@
     <Compile Include="DocumentTypeCode.cs" />
     <Compile Include="EncounterConcern.cs" />
     <Compile Include="CustomCode.cs" />
+    <Compile Include="HospitalAddress.cs" />
     <Compile Include="IIntakeQuestionnaire.cs" />
     <Compile Include="IntakeQuestionnaire.cs" />
     <Compile Include="NewbornRecord.cs" />

--- a/SnapMD.ConnectedCare.Sdk.sln
+++ b/SnapMD.ConnectedCare.Sdk.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnapMD.ConnectedCare.Sdk", "SnapMD.ConnectedCare.Sdk\SnapMD.ConnectedCare.Sdk.csproj", "{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnapMD.ConnectedCare.Sdk", "SnapMD.ConnectedCare.Sdk\SnapMD.ConnectedCare.Sdk.csproj", "{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnapMD.ConnectedCare.Sdk.Tests", "SnapMD.ConnectedCare.Sdk.Tests\SnapMD.ConnectedCare.Sdk.Tests.csproj", "{49F684C1-8787-49D7-9BFE-BA066658573D}"
 EndProject
@@ -22,14 +22,14 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Debug|x64.ActiveCfg = Debug|x64
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Debug|x64.Build.0 = Debug|x64
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Release|x64.ActiveCfg = Release|x64
-		{3D0A122B-6634-4AEE-B5B7-C71FD58DF02F}.Release|x64.Build.0 = Release|x64
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Debug|x64.ActiveCfg = Debug|x64
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Debug|x64.Build.0 = Debug|x64
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Release|x64.ActiveCfg = Release|x64
+		{7C7BE4A0-39AC-4BD5-9A86-8D16D5258CFC}.Release|x64.Build.0 = Release|x64
 		{49F684C1-8787-49D7-9BFE-BA066658573D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{49F684C1-8787-49D7-9BFE-BA066658573D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{49F684C1-8787-49D7-9BFE-BA066658573D}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -50,4 +50,3 @@ Global
 		SolutionGuid = c4edf793-fbed-46bc-bdad-cb344c06037e
 	EndGlobalSection
 EndGlobal
-

--- a/SnapMD.ConnectedCare.Sdk/ApiCall.cs
+++ b/SnapMD.ConnectedCare.Sdk/ApiCall.cs
@@ -47,24 +47,14 @@ namespace SnapMD.ConnectedCare.Sdk
             WebClientInstance = client;
         }
 
+        #region Properties
+
         public bool RequiresAuthentication { get; set; }
         public bool NotFound { get; private set; }
         public bool ServerError { get; private set; }
+        #endregion
 
-        protected virtual T MakeCall<T>(string apiPath)
-        {
-            var url = new Uri(_baseUri, apiPath);
-            try
-            {
-                var data = MakeCall(wc => wc.DownloadString(url));
-                return JsonConvert.DeserializeObject<T>(data.ToString());
-            }
-            catch (Exception ex)
-            {
-                throw new SnapSdkException("Unable to load api at url: " + url, ex);
-            }
-        }
-
+        #region JObject versions
         protected virtual JObject MakeCall(string pathFormat, params object[] arguments)
         {
             return MakeCall(string.Format(pathFormat, arguments));
@@ -83,54 +73,12 @@ namespace SnapMD.ConnectedCare.Sdk
             }
         }
 
-
-        protected JObject MakeCall(Func<IWebClient, string> executeFunc)
+        protected virtual JObject MakeCall(Func<IWebClient, string> executeFunc)
         {
             // Allow domains we don't have a certificate for
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
             SetHeaders(WebClientInstance);
             return MakeCall(WebClientInstance, executeFunc);
-        }
-
-        private void SetHeaders(IWebClient wc)
-        {
-            if (RequiresAuthentication || _bearerToken != null)
-            {
-                AddHeader(wc, "Authorization", "Bearer " + _bearerToken);
-            }
-
-            AddHeader(wc, "X-Developer-Id", _developerId);
-            AddHeader(wc, "X-Api-Key", _apiKey);
-        }
-
-        private void AddHeader(IWebClient wc, string name, string value)
-        {
-            if (!string.IsNullOrEmpty(value))
-            {
-                wc.Headers[name] = value;
-            }
-        }
-
-        private void Parse404(WebException wex)
-        {
-            var response = wex.Response as HttpWebResponse;
-            if (response == null)
-            {
-                throw new Exception("No response from the API.", wex);
-            }
-
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                Debug.WriteLine("Four, oh Four...");
-                NotFound = true;
-            }
-
-            if (response.StatusCode == HttpStatusCode.InternalServerError)
-            {
-                Debug.WriteLine("Piper down!");
-                ServerError = true;
-                throw new SnapSdkException("There was an error on the API service.", wex);
-            }
         }
 
         protected JObject MakeCall(IWebClient wc, Func<IWebClient, string> executeFunc)
@@ -192,5 +140,130 @@ namespace SnapMD.ConnectedCare.Sdk
                 throw new SnapSdkException("Unable to load api at url: " + url, ex);
             }
         }
+
+        #endregion
+
+        #region Generic versions
+
+        protected virtual T MakeCall<T>(string apiPath, params object[] arguments)
+        {
+            var url = new Uri(_baseUri, string.Format(apiPath, arguments));
+            try
+            {
+                var data = MakeCall(wc => wc.DownloadString(url));
+                return JsonConvert.DeserializeObject<T>(data.ToString());
+            }
+            catch (Exception ex)
+            {
+                throw new SnapSdkException("Unable to load api at url: " + url, ex);
+            }
+        }
+
+        protected virtual T MakeCall<T>(Func<IWebClient, T> executeFunc)
+        {
+            // Allow domains we don't have a certificate for
+            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+            SetHeaders(WebClientInstance);
+            return MakeCall<T>(WebClientInstance, executeFunc);
+        }
+
+        protected virtual T MakeCall<T>(IWebClient wc, Func<IWebClient, T> executeFunc)
+        {
+            try
+            {
+                var responseObj = executeFunc.Invoke(wc);
+                return responseObj;
+            }
+            catch (WebException wex)
+            {
+                Parse404(wex);
+            }
+
+            return default(T);
+        }
+
+        protected virtual T Put<T>(string apiPath, object data)
+        {
+            return UploadData<T>(apiPath, "PUT", data);
+        }
+
+        protected virtual T Post<T>(string apiPath, object data)
+        {
+            return UploadData<T>(apiPath, "POST", data);
+        }
+
+        private T UploadData<T>(string apiPath, string method, object data)
+        {
+            var url = new Uri(_baseUri, apiPath);
+            try
+            {
+                return MakeCall<T>(wc =>
+                {
+                    // Allow domains we don't have a certificate for
+                    ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+                    if (RequiresAuthentication)
+                    {
+                        wc.Headers[HttpRequestHeader.Authorization] = "Bearer " + _bearerToken;
+                    }
+
+                    wc.Headers[HttpRequestHeader.ContentType] = "application/json";
+
+
+                    string result = wc.UploadString(url, method, JsonConvert.SerializeObject(data));
+                    return JsonConvert.DeserializeObject<T>(result);
+                });
+            }
+            catch (Exception ex)
+            {
+                throw new SnapSdkException("Unable to load api at url: " + url, ex);
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+        private void SetHeaders(IWebClient wc)
+        {
+            if (RequiresAuthentication || _bearerToken != null)
+            {
+                AddHeader(wc, "Authorization", "Bearer " + _bearerToken);
+            }
+
+            AddHeader(wc, "X-Developer-Id", _developerId);
+            AddHeader(wc, "X-Api-Key", _apiKey);
+        }
+
+        private void AddHeader(IWebClient wc, string name, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                wc.Headers[name] = value;
+            }
+        }
+
+        private void Parse404(WebException wex)
+        {
+            var response = wex.Response as HttpWebResponse;
+            if (response == null)
+            {
+                throw new Exception("No response from the API.", wex);
+            }
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                Debug.WriteLine("Four, oh Four...");
+                NotFound = true;
+            }
+
+            if (response.StatusCode == HttpStatusCode.InternalServerError)
+            {
+                Debug.WriteLine("Piper down!");
+                ServerError = true;
+                throw new SnapSdkException("There was an error on the API service.", wex);
+            }
+        }
+
+        #endregion
     }
 }

--- a/SnapMD.ConnectedCare.Sdk/DocumentsApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/DocumentsApi.cs
@@ -32,8 +32,8 @@ namespace SnapMD.ConnectedCare.Sdk
             }
 
             // v2/publicdocuments?documentType=1&hospitalId=126
-            var o = MakeCall("v2/publicdocuments?documentType={0}&hospitalId={1}", (int)documentType, hospitalId);
-            return o.ToObject<ApiResponseV2<DocumentsResponse>>();
+            var o = MakeCall<ApiResponseV2<DocumentsResponse>>("v2/publicdocuments?documentType={0}&hospitalId={1}", (int)documentType, hospitalId);
+            return o;
         }
     }
 

--- a/SnapMD.ConnectedCare.Sdk/HospitalApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/HospitalApi.cs
@@ -10,8 +10,9 @@
 //    limitations under the License.
 using System;
 using Newtonsoft.Json.Linq;
-
+using SnapMD.ConnectedCare.ApiModels;
 using SnapMD.ConnectedCare.Sdk.Interfaces;
+using SnapMD.ConnectedCare.Sdk.Models;
 
 namespace SnapMD.ConnectedCare.Sdk
 {
@@ -22,25 +23,29 @@ namespace SnapMD.ConnectedCare.Sdk
         {
         }
 
-        public string GetAddress()
+        //TODO: This should be a POST call instead of GET
+        public string PostAddress(HospitalAddress newAddress)
         {
-            var o = MakeCall("hospitaladdress");
+            //TODO: instead of bool, this could be a POCO, need to consult with Aaron
+            var o = Post("hospitaladdress", newAddress);
             return Convert.ToString(o["data"]);
         }
         
+        //TODO: This no longer exists
         public string GetHospitalAddress()
         {
             var o = MakeCall("hospital/address");
             return Convert.ToString(o["data"]);
         }
 
+        //TODO: Convert to API Response?
         public string GetHospitalAddressById(int hospitalId)
         {
-            var o = MakeCall("HospitalAddress/" + hospitalId);
-            var data = o["data"];
-            return Convert.ToString(data["addressText"]);
+            var o = MakeCall<ApiResponse<HospitalAddress>>("hospitaladdress");
+            return o.Data.address;
         }
-
+        
+        //TODO: This no longer exists
         public JObject GetHospital()
         {
             var o = MakeCall("hospital");

--- a/SnapMD.ConnectedCare.Sdk/IntakeApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/IntakeApi.cs
@@ -34,9 +34,9 @@ namespace SnapMD.ConnectedCare.Sdk
 
         public List<CodeSetResponse> GetIntakeItems(int HospitalId)
         {
-            var result = MakeCall(string.Format("v2/codesets?hospitalId={0}&fields={1}",HospitalId,"medicalconditions,medications,medicationallergies,consultprimaryconcerns,consultsecondaryconcerns"));
+            var result = MakeCall<ApiResponseV2<CodeSetResponse>>(string.Format("v2/codesets?hospitalId={0}&fields={1}", HospitalId, "medicalconditions,medications,medicationallergies,consultprimaryconcerns,consultsecondaryconcerns"));
 
-            return ((JObject)result).ToObject<ApiResponseV2<CodeSetResponse>>().Data.ToList();
+            return result.Data.ToList();
 
             //while (dataEnumerator.MoveNext())
             //    if (dataEnumerator.Current != null)

--- a/SnapMD.ConnectedCare.Sdk/PaymentsApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/PaymentsApi.cs
@@ -33,6 +33,7 @@ namespace SnapMD.ConnectedCare.Sdk
         public JObject GetCustomerProfile(int userId)
         {
             //API looks so strange 
+            //TODO: (Chris: No API corresponds to this path)
             var result = MakeCall(string.Format("hospital/{0}/payments", HospitalId));
             return result;
         }

--- a/SnapMD.ConnectedCare.Sdk/UserApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/UserApi.cs
@@ -24,9 +24,9 @@ namespace SnapMD.ConnectedCare.Sdk
 
         public int? GetUserId()
         {
-            var o = MakeCall("v2/account/user");
+            var o = MakeCall<ApiResponseV2<SerializableUser>>("v2/account/user");
 
-            var dataEnumerator = ((JObject)o).ToObject<ApiResponseV2<SerializableUser>>().Data.GetEnumerator();
+            var dataEnumerator = o.Data.GetEnumerator();
 
             while (dataEnumerator.MoveNext())
                 if (dataEnumerator.Current.id > 0)


### PR DESCRIPTION
SUMMARY: I setup the ApiCalls that will be used by the non-JObject methods. Also found some calls that do not have a corresponding Api on SnapMD.Api--for now these were noted with //TODO comments

[Created POCO - HospitalAddress]
Steps to remove JObjects, I started adding POCOs, starting with HospitalAddress.cs => can you let me know if I should continue this path or if you have comments, suggestions?

[Templated versions of ApiCall.cs methdos]
Created equivalent templated methods to ready for non-JObject calls.

[Apis with no corresponding ApiController Api]
I added //TODO comments on some Api calls with no ApiController equivalent.  What do you think -- Just delete these directly?

Thanks.
Chris
