### PR TITLE
Added CustomCode constructor, and removed PatientMedicalHistoryProfile

### DIFF
--- a/SnapMD.ConnectedCare.ApiModels/CustomCode.cs
+++ b/SnapMD.ConnectedCare.ApiModels/CustomCode.cs
@@ -18,6 +18,12 @@ namespace SnapMD.ConnectedCare.ApiModels
 {
     public struct CustomCode : ICustomCode
     {
+        public CustomCode(int code, string description) : this()
+        {
+            Code = code;
+            Description = description;
+        }
+
         public CustomCode(string singleLine = null) : this()
         {
             Description = "";

--- a/SnapMD.ConnectedCare.ApiModels/SnapMD.ConnectedCare.ApiModels.csproj
+++ b/SnapMD.ConnectedCare.ApiModels/SnapMD.ConnectedCare.ApiModels.csproj
@@ -81,6 +81,7 @@
     <Compile Include="NewbornRecord.cs" />
     <Compile Include="PatientAccountInfo.cs" />
     <Compile Include="PatientConsultationInfo.cs" />
+    <Compile Include="PatientMedicalHistoryProfile.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResponseObservableItem.cs" />
     <Compile Include="SerializableToken.cs" />

--- a/SnapMD.ConnectedCare.ApiModels/SnapMD.ConnectedCare.ApiModels.csproj
+++ b/SnapMD.ConnectedCare.ApiModels/SnapMD.ConnectedCare.ApiModels.csproj
@@ -81,7 +81,6 @@
     <Compile Include="NewbornRecord.cs" />
     <Compile Include="PatientAccountInfo.cs" />
     <Compile Include="PatientConsultationInfo.cs" />
-    <Compile Include="PatientMedicalHistoryProfile.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResponseObservableItem.cs" />
     <Compile Include="SerializableToken.cs" />

--- a/SnapMD.ConnectedCare.Sdk/ApiCall.cs
+++ b/SnapMD.ConnectedCare.Sdk/ApiCall.cs
@@ -57,7 +57,7 @@ namespace SnapMD.ConnectedCare.Sdk
             try
             {
                 var data = MakeCall(wc => wc.DownloadString(url));
-                return JsonConvert.DeserializeObject<T>(data.ToString());
+                return data.ToObject<T>();
             }
             catch (Exception ex)
             {

--- a/SnapMD.ConnectedCare.Sdk/HospitalApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/HospitalApi.cs
@@ -28,12 +28,6 @@ namespace SnapMD.ConnectedCare.Sdk
             return Convert.ToString(o["data"]);
         }
         
-        public string GetHospitalAddress()
-        {
-            var o = MakeCall("hospital/address");
-            return Convert.ToString(o["data"]);
-        }
-
         public string GetHospitalAddressById(int hospitalId)
         {
             var o = MakeCall("HospitalAddress/" + hospitalId);

--- a/SnapMD.ConnectedCare.Sdk/PatientMedicalProfileApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/PatientMedicalProfileApi.cs
@@ -22,18 +22,18 @@ namespace SnapMD.ConnectedCare.Sdk
         {
         }
 
-        public ApiResponseV2<IPatientMedicalHistoryProfile> GetPatientData(int patientId)
+        public ApiResponseV2<PatientMedicalHistoryProfile> GetPatientData(int patientId)
         {
             var url = string.Format("v2/patients/medicalprofile/{0}", patientId);
-            var result = MakeCall<ApiResponseV2<IPatientMedicalHistoryProfile>>(url);
+            var result = MakeCall<ApiResponseV2<PatientMedicalHistoryProfile>>(url);
             return result;
         }
 
-        public ApiResponseV2<IPatientMedicalHistoryProfile> UpdatePatientData(int patientId, IPatientMedicalHistoryProfile profile)
+        public ApiResponseV2<PatientMedicalHistoryProfile> UpdatePatientData(int patientId, IPatientMedicalHistoryProfile profile)
         {
             var url = string.Format("v2/patients/medicalprofile/{0}", patientId);
-            var result = Put<IPatientMedicalHistoryProfile>(url, profile);
-            return new ApiResponseV2<IPatientMedicalHistoryProfile>(result);
+            var result = Put(url, profile).ToObject<PatientMedicalHistoryProfile>();
+            return new ApiResponseV2<PatientMedicalHistoryProfile>(result);
         }
     }
 }

--- a/SnapMD.ConnectedCare.Sdk/PaymentsApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/PaymentsApi.cs
@@ -30,7 +30,7 @@ namespace SnapMD.ConnectedCare.Sdk
 
         public int HospitalId { get; private set; }
 
-        public JObject GetCustomerProfile(int patientUserId)
+        public JObject GetCustomerProfile(int? patientUserId)
         {
             //API looks so strange 
             var result = MakeCall(string.Format("patients/{0}/payments", patientUserId));

--- a/SnapMD.ConnectedCare.Sdk/TokenApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/TokenApi.cs
@@ -34,14 +34,17 @@ namespace SnapMD.ConnectedCare.Sdk
                 hospitalId = HospitalId,
                 userTypeId = 1
             };
-
-            var result = Post("v2/account/token", request);
             
-            var dataEnumerator = result.ToObject<ApiResponseV2<SerializableToken>>().Data.GetEnumerator();
-
-            while (dataEnumerator.MoveNext())
-                if (dataEnumerator.Current.access_token != null)
-                    return dataEnumerator.Current.access_token;
+            var response = Post("v2/account/token", request);
+            
+            var dataEnumerator = response.ToObject<ApiResponseV2<SerializableToken>>();
+            if (dataEnumerator.Data != null)
+            {
+                foreach (var entry in dataEnumerator.Data)
+                {
+                    return entry.access_token;
+                }
+            }
 
             return null;
         }

--- a/SnapMD.ConnectedCare.Sdk/UserApi.cs
+++ b/SnapMD.ConnectedCare.Sdk/UserApi.cs
@@ -24,19 +24,17 @@ namespace SnapMD.ConnectedCare.Sdk
 
         public int? GetUserId()
         {
-            var o = MakeCall("v2/account/user");
+            var response = MakeCall("v2/account/user");
 
-            var dataEnumerator = ((JObject)o).ToObject<ApiResponseV2<SerializableUser>>().Data.GetEnumerator();
 
-            while (dataEnumerator.MoveNext())
-                if (dataEnumerator.Current.id > 0)
-                    return dataEnumerator.Current.id;
-            
-            //if (o != null && o["id"] != null)
-            //{
-            //    var userId = Convert.ToInt32(o["id"]);
-            //    return userId;
-            //}
+            var dataEnumerator = response.ToObject<ApiResponseV2<SerializableUser>>();
+            if (dataEnumerator.Data != null)
+            {
+                foreach (var entry in dataEnumerator.Data)
+                {
+                    return entry.id;
+                }
+            }
 
             return null;
         }


### PR DESCRIPTION
The interface remains (IPatientMedicalHistoryProfile) on the SDK, but the POCO is moved to the main .sln.  It is similar to other POCOs which are in the main .sln, plus creation of other support classes around it (e.g., adapters)
