### PR TITLE
#9070 Changed API for demand consultations

### DIFF
--- a/SnapMD.VirtualCare.ApiModels/FamilyMember.cs
+++ b/SnapMD.VirtualCare.ApiModels/FamilyMember.cs
@@ -45,5 +45,7 @@ namespace SnapMD.VirtualCare.ApiModels
         public string MobilePhone { get; set; }
         public int? OrganationId { get; set; }
         public int? LocationId { get; set; }
+
+        public bool? ProviderAvailable { get; set; }
     }
 }

--- a/SnapMD.VirtualCare.ApiModels/Scheduling/OnDemandAvailabilityResponse.cs
+++ b/SnapMD.VirtualCare.ApiModels/Scheduling/OnDemandAvailabilityResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace SnapMD.VirtualCare.ApiModels.Scheduling
+﻿using System.Collections.Generic;
+
+namespace SnapMD.VirtualCare.ApiModels.Scheduling
 {
     /// <summary>
     /// Response Model for OnDemandAvailability
@@ -15,11 +17,8 @@
         public bool ProviderOnDemandEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the count of ondemand availability blocks at the moment.
+        /// The list of family members with <see cref="FamilyMember.ProviderAvailable"/> property set.
         /// </summary>
-        /// <value>
-        /// The count of ondemand availability blocks at the moment.
-        /// </value>
-        public int OnDemandAvailabilityBlockCount { get; set; }
+        public List<FamilyMember> FamilyMembers { get; set; }
     }
 }

--- a/SnapMD.VirtualCare.ApiModels/Scheduling/OnDemandAvailabilityResponse.cs
+++ b/SnapMD.VirtualCare.ApiModels/Scheduling/OnDemandAvailabilityResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace SnapMD.VirtualCare.ApiModels.Scheduling
 {
@@ -20,5 +21,11 @@ namespace SnapMD.VirtualCare.ApiModels.Scheduling
         /// The list of family members with <see cref="FamilyMember.ProviderAvailable"/> property set.
         /// </summary>
         public List<FamilyMember> FamilyMembers { get; set; }
+
+        /// <summary>
+        /// Deprecated
+        /// </summary>
+        [Obsolete("This field is no more calculated in API call")]
+        public int OnDemandAvailabilityBlockCount { get; set; }
     }
 }


### PR DESCRIPTION
The field OnDemandAvailabilityBlockCount was deleted, so branches other than feature/9070 in main repository would generate compile errors. Shouldn't this request be merged into another branch, e.g. feature/visibilityrules?