### PR TITLE
Ticket #10094 Fix.

### DIFF
--- a/SnapMD.VirtualCare.ApiModels/UserProfilesResult.cs
+++ b/SnapMD.VirtualCare.ApiModels/UserProfilesResult.cs
@@ -265,5 +265,10 @@ namespace SnapMD.VirtualCare.ApiModels
         /// Guardian user id (for dependent patients).
         /// </summary>
         public int? GuardianUserId { get; set; }
+
+        /// <summary>
+        /// User role description.
+        /// </summary>
+        public string UserRoleDescription { get; set; }
     }
 }


### PR DESCRIPTION
We can use UserRoleDescription in several pages in order to check if user is Account Admin or common user.

For example in ticket #10094 we will use this check in order to disable user profiles list for co-user.