### PR TITLE
Ticket # 10849 Fix.

### DIFF
--- a/SnapMD.VirtualCare.ApiModels/PatientProfileFieldChangesTrackingRequest.cs
+++ b/SnapMD.VirtualCare.ApiModels/PatientProfileFieldChangesTrackingRequest.cs
@@ -8,7 +8,7 @@
 
         public bool? City { get; set; }
 
-        public bool? Country { get; set; }
+        public bool? MobilePhoneCountryCodeId { get; set; }
 
         public bool? CurrentMedications { get; set; }
 

--- a/SnapMD.VirtualCare.ApiModels/PatientProfileFieldChangesTrackingRequest.cs
+++ b/SnapMD.VirtualCare.ApiModels/PatientProfileFieldChangesTrackingRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace SnapMD.Web.Api.Models
+﻿using System;
+
+namespace SnapMD.Web.Api.Models
 {
     public class PatientProfileFieldChangesTrackingRequest
     {
@@ -7,6 +9,9 @@
         public bool? BloodType { get; set; }
 
         public bool? City { get; set; }
+
+        [Obsolete("Use MobilePhoneCountryCodeId instead")]
+        public bool? Country { get; set; }
 
         public bool? MobilePhoneCountryCodeId { get; set; }
 

--- a/SnapMD.VirtualCare.ApiModels/PatientUpdateRequest.cs
+++ b/SnapMD.VirtualCare.ApiModels/PatientUpdateRequest.cs
@@ -35,6 +35,10 @@ namespace SnapMD.VirtualCare.ApiModels
         public int? OrganizationId { get; set; }
         public int? LocationId { get; set; }
         public IList<IdentifierValue> Identifiers { get; set; }
+
+        [Obsolete("Use MobilePhoneCountryCodeId instead")]
+        public string CountryCode { get; set; }
+
         public int? MobilePhoneCountryCodeId { get; set; }
     }
 }

--- a/SnapMD.VirtualCare.ApiModels/PatientUpdateRequest.cs
+++ b/SnapMD.VirtualCare.ApiModels/PatientUpdateRequest.cs
@@ -35,6 +35,6 @@ namespace SnapMD.VirtualCare.ApiModels
         public int? OrganizationId { get; set; }
         public int? LocationId { get; set; }
         public IList<IdentifierValue> Identifiers { get; set; }
-        public string CountryCode { get; set; }
+        public int? MobilePhoneCountryCodeId { get; set; }
     }
 }


### PR DESCRIPTION
SDK changes for Ticket #10849.
Mobile phone country code had a wrong name 'Country'.
I renamed this field in order to avid confusion.

Now instead of country code string representation ("+44" for Great Britain, "+1" for US, Anguilla and some other countries) we pass TelephoneCodeId which is unique.